### PR TITLE
Quoted strings in connect template

### DIFF
--- a/templates/connect.erb
+++ b/templates/connect.erb
@@ -3,8 +3,8 @@ connect "<%= @name %>" {
     send_password = "<%= @send_password %>";
     accept_password = "<%= @accept_password %>";
     port = <%= @port %>;
-    hub_mask = <%= @hub_mask %>;
-    class = <%= @connectclass %>;
+    hub_mask = "<%= @hub_mask %>";
+    class = "<%= @connectclass %>";
     flags = <%= Array(@flags).join(', ') %>;
 <% if @ipv6 -%>
     aftype = ipv6;


### PR DESCRIPTION
Both hub_mask and class need to be quoted strings.
